### PR TITLE
Sample name missmatch between sampleData and Spectra

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -23,7 +23,10 @@ Authors@R: c(person(given = "Laurent", family = "Gatto",
              person(given = "Sebastian", family = "Gibb",
                     comment = c(ORCID = "0000-0001-7406-4443"),
                     email = "mail@sebastiangibb.de",
-                    role = "aut"))
+                    role = "aut"),
+             person(given = "Tuomas", family = "Borman",
+                    comment = c(ORCID = "0000-0002-8563-8884"),
+                    role = "ctb"))
 Depends:
     R (>= 4.2),
     ProtGenerics (>= 1.35.2),

--- a/R/MsExperiment-functions.R
+++ b/R/MsExperiment-functions.R
@@ -399,6 +399,7 @@ readMsExperiment <- function(spectraFiles = character(),
     sampleData$spectraOrigin <- spectraFiles
     if (!inherits(sampleData, "DataFrame"))
         sampleData <- DataFrame(sampleData)
+    rownames(sampleData) <- basename(spectraFiles)
     x <- MsExperiment()
     sampleData(x) <- sampleData
     spectra(x) <- Spectra(spectraFiles, ...)

--- a/R/MsExperiment-functions.R
+++ b/R/MsExperiment-functions.R
@@ -399,6 +399,11 @@ readMsExperiment <- function(spectraFiles = character(),
     sampleData$spectraOrigin <- spectraFiles
     if (!inherits(sampleData, "DataFrame"))
         sampleData <- DataFrame(sampleData)
+    if (!(is.null(rownames(sampleData)) ||
+            all(rownames(sampleData) == basename(spectraFiles)))) {
+        stop("'rownames(sampleData)' must be NULL or equal to ",
+             "'basename(spectraFiles)'.")
+    }
     rownames(sampleData) <- basename(spectraFiles)
     x <- MsExperiment()
     sampleData(x) <- sampleData

--- a/tests/testthat/test_MsExperiment.R
+++ b/tests/testthat/test_MsExperiment.R
@@ -262,3 +262,21 @@ test_that("filterSpectra,MsExperiment,function works", {
     expect_equal(a$scanIndex, ref$scanIndex)
     expect_equal(a$dataOrigin, ref$dataOrigin)
 })
+
+test_that("readMsExperiment checks that sample names match", {
+    df <- data.frame(
+        row.names = c("sample1", "sample2")
+    )
+    # Error: rownames(df) do not match with basename(fls)
+    res <- readMsExperiment(spectraFiles = fls, sampleData = df) |>
+        expect_error()
+    # No error: rownames of sample metadata file match with basename(files)
+    rownames(df) <- basename(fls)
+    res <- readMsExperiment(spectraFiles = fls, sampleData = df) |>
+        expect_no_error()
+    # No error: rownames are not included, the function expects that user takes
+    # care that the order of sample metadata matches with files.
+    rownames(df) <- NULL
+    res <- readMsExperiment(spectraFiles = fls, sampleData = df) |>
+        expect_no_error()
+})


### PR DESCRIPTION
Hello!

I found out that `MsExperiment` constructor does not validate sample names. This can lead to situation were sample names of `Spectra` and `sampleData` do not match. This does not cause big problems since it seems that the methods use indexing instead of names. However, when `SummarizedExperiment` is constructed from the results and sample names do not match, it leads to error which is hard for user to solve.

> Error in SummarizedExperiment(assays = list(raw = featureValues(object,  : 
>   the rownames and colnames of the supplied assay(s) must be NULL or identical to those of the SummarizedExperiment object  (or derivative) to construct

This PR implements input validation which checks that these sample names match if they are provided. This follows similar logic as `SummarizedExperiment`'s constructor; the names must match completely or they must be `NULL`.

Below is code that describes the problem:

```
# This works as sampleData does not have rownames
library(MsExperiment)
files <- c(
    system.file('cdf/KO/ko15.CDF', package = "faahKO"),
    system.file('cdf/KO/ko16.CDF', package = "faahKO")
    )
fls <- normalizePath(files)
df <- data.frame(
    mzML_file = basename(fls),
    dataOrigin = fls,
    sample = c("ko15", "ko16")
    )
res <- readMsExperiment(spectraFiles = fls, sampleData = df)
p <- CentWaveParam()
res <- findChromPeaks(res, param = p)
#
p <- PeakDensityParam(
    sampleGroups = sampleData(res)$sample)
res <- groupChromPeaks(res, param = p)
#
se <- quantify(res, method = "sum")
```

```
# This does not work as sampleData and Spectra have different rownames 
rownames(df) <- c("ko15", "ko16")
res <- readMsExperiment(spectraFiles = fls, sampleData = df)
p <- CentWaveParam()
res <- findChromPeaks(res, param = p)
#
p <- PeakDensityParam(
    sampleGroups = sampleData(res)$sample)
res <- groupChromPeaks(res, param = p)
#
se <- quantify(res, method = "sum")
```
-Tuomas

<details>

<summary>Session info</summary>

```
> sessionInfo()
R version 4.4.2 (2024-10-31)
Platform: x86_64-pc-linux-gnu
Running under: Linux Mint 21

Matrix products: default
BLAS:   /opt/R/4.4.2/lib/R/lib/libRblas.so 
LAPACK: /usr/lib/x86_64-linux-gnu/lapack/liblapack.so.3.10.0

locale:
 [1] LC_CTYPE=en_US.UTF-8       LC_NUMERIC=C               LC_TIME=en_US.UTF-8        LC_COLLATE=en_US.UTF-8    
 [5] LC_MONETARY=fi_FI.UTF-8    LC_MESSAGES=en_US.UTF-8    LC_PAPER=fi_FI.UTF-8       LC_NAME=C                 
 [9] LC_ADDRESS=C               LC_TELEPHONE=C             LC_MEASUREMENT=fi_FI.UTF-8 LC_IDENTIFICATION=C       

time zone: Europe/Helsinki
tzcode source: system (glibc)

attached base packages:
[1] stats4    stats     graphics  grDevices utils     datasets  methods   base     

other attached packages:
[1] MsExperiment_1.9.1     MetaboCoreUtils_1.14.0 Spectra_1.16.0         S4Vectors_0.43.2       BiocGenerics_0.51.1   
[6] xcms_4.3.3             BiocParallel_1.39.0    testthat_3.2.1.1       ProtGenerics_1.37.1   

loaded via a namespace (and not attached):
  [1] RColorBrewer_1.1-3          rstudioapi_0.16.0           jsonlite_1.8.9              MultiAssayExperiment_1.31.5
  [5] magrittr_2.0.3              MALDIquant_1.22.3           fs_1.6.4                    zlibbioc_1.51.1            
  [9] vctrs_0.6.5                 memoise_2.0.1               htmltools_0.5.8.1           S4Arrays_1.5.7             
 [13] usethis_3.0.0               progress_1.2.3              SparseArray_1.5.37          mzID_1.43.0                
 [17] htmlwidgets_1.6.4           desc_1.4.3                  plyr_1.8.9                  impute_1.79.0              
 [21] cachem_1.1.0                igraph_2.0.3                mime_0.12                   lifecycle_1.0.4            
 [25] iterators_1.0.14            pkgconfig_2.0.3             Matrix_1.6-5                R6_2.5.1                   
 [29] fastmap_1.2.0               GenomeInfoDbData_1.2.12     MatrixGenerics_1.17.0       shiny_1.9.1                
 [33] clue_0.3-65                 digest_0.6.37               pcaMethods_1.97.0           colorspace_2.1-1           
 [37] rprojroot_2.0.4             pkgload_1.4.0               GenomicRanges_1.57.1        fansi_1.0.6                
 [41] httr_1.4.7                  abind_1.4-8                 compiler_4.4.2              remotes_2.5.0              
 [45] withr_3.0.1                 doParallel_1.0.17           DBI_1.2.3                   pkgbuild_1.4.4             
 [49] MASS_7.3-61                 DelayedArray_0.31.11        sessioninfo_1.2.2           mzR_2.41.1                 
 [53] tools_4.4.2                 PSMatch_1.9.0               httpuv_1.6.15               glue_1.7.0                 
 [57] QFeatures_1.15.3            promises_1.3.0              grid_4.4.2                  cluster_2.1.6              
 [61] reshape2_1.4.4              generics_0.1.3              gtable_0.3.5                preprocessCore_1.67.0      
 [65] tidyr_1.3.1                 hms_1.1.3                   utf8_1.2.4                  XVector_0.45.0             
 [69] foreach_1.5.2               pillar_1.9.0                stringr_1.5.1               limma_3.61.9               
 [73] later_1.3.2                 dplyr_1.1.4                 lattice_0.22-6              tidyselect_1.2.1           
 [77] miniUI_0.1.1.1              IRanges_2.39.2              SummarizedExperiment_1.35.1 Biobase_2.65.1             
 [81] statmod_1.5.0               devtools_2.4.5              MSnbase_2.31.1              brio_1.1.5                 
 [85] matrixStats_1.4.1           stringi_1.8.4               UCSC.utils_1.1.0            lazyeval_0.2.2             
 [89] codetools_0.2-20            MsCoreUtils_1.17.2          tibble_3.2.1                BiocManager_1.30.25        
 [93] cli_3.6.3                   affyio_1.75.1               xtable_1.8-4                munsell_0.5.1              
 [97] Rcpp_1.0.14                 GenomeInfoDb_1.41.1         MassSpecWavelet_1.71.0      XML_3.99-0.17              
[101] parallel_4.4.2              ellipsis_0.3.2              ggplot2_3.5.1               prettyunits_1.2.0          
[105] profvis_0.4.0               AnnotationFilter_1.29.0     urlchecker_1.0.1            MsFeatures_1.13.0          
[109] scales_1.3.0                affy_1.83.0                 ncdf4_1.23                  purrr_1.0.2                
[113] crayon_1.5.3                rlang_1.1.4                 vsn_3.73.0      
```


</details>

